### PR TITLE
Make events order deterministic

### DIFF
--- a/src/Noir/Classes/Connection.lua
+++ b/src/Noir/Classes/Connection.lua
@@ -37,6 +37,7 @@
 ]]
 ---@class NoirConnection: NoirClass
 ---@field ID integer The ID of this connection
+---@field Index integer The index of this connection in ParentEvent.ConnectionsOrder
 ---@field Callback function The callback that is assigned to this connection
 ---@field ParentEvent NoirEvent The event that this connection is connected to
 ---@field Connected boolean Whether or not this connection is connected


### PR DESCRIPTION
Instead of using `pairs` which is known to be non-deterministic ([see the docs](https://www.lua.org/manual/5.4/manual.html#pdf-next)) we should use `ipairs`.
This does mean additional book-keeping is required, but it shouldn't affect performance much unless an extreme amount of disconnections from the event are done.

Only events connected after the disconnected event (at time of connection) need their book-kept index updated.
Due to also fixing a bug with modifying a table during iteration, I also included an optimisation to my changes which should in most cases make the impact of disconnections no different in time complexity.